### PR TITLE
Fix RecursionError Exception

### DIFF
--- a/siegeapi/auth.py
+++ b/siegeapi/auth.py
@@ -249,6 +249,12 @@ class Auth:
     async def get(self, *args, retries: int = 0, json_: bool = True, new: bool = False, **kwargs) -> Union[dict, str]:
         """Sends a GET request to the Ubisoft API.
         Intended for internal use only."""
+
+        MAX_RETRIES = 3
+
+        if retries >= MAX_RETRIES:
+            raise InvalidRequest(f"Exceeded max retry attempts in get() after {MAX_RETRIES} tries.")
+
         if (not self.key and not new) or (not self.new_key and new):
             last_error = None
             for _ in range(self.max_connect_retries):


### PR DESCRIPTION
Add retry cap to `get()` to prevent infinite recursion and RecursionError

`Auth.get()` encounters the exception `RecursionError: maximum recursion depth exceeded in comparison` if API is left running long enough for self.key or self.new_key to expire so when a request is made that triggers a 401 response from Ubisoft (expired token) Auth.get() attempts to recover by clearing the token and recursively calling itself:

```python
self.key = None
return await self.get(*args, retries=retries + 1, **kwargs)
```

If the refreshed session still leads to a 401 (e.g. login fails, auth is broken, etc.), `get()` continues calling itself until the recursion limit is hit, triggering the exception...

